### PR TITLE
Allow all json extensions 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=7.1",
         "ext-rdkafka": "^4.0",
         "ext-pcntl": "^7.2",
-        "ext-json": "*",
+        "ext-json": "^1.6 || ^7.4",
         "flix-tech/avro-serde-php": "^1.3",
         "illuminate/support": "^5.8 || ^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=7.1",
         "ext-rdkafka": "^4.0",
         "ext-pcntl": "^7.2",
-        "ext-json": "^1.6",
+        "ext-json": "*",
         "flix-tech/avro-serde-php": "^1.3",
         "illuminate/support": "^5.8 || ^6.0"
     },

--- a/src/Adapters/CacheAdapter.php
+++ b/src/Adapters/CacheAdapter.php
@@ -15,7 +15,7 @@ class CacheAdapter implements \FlixTech\SchemaRegistryApi\Registry\CacheAdapter
      *
      * @return void
      */
-    public function cacheSchemaWithId(AvroSchema $schema, int $schemaId)
+    public function cacheSchemaWithId(AvroSchema $schema, int $schemaId): void
     {
         Cache::add($this->makeKeyFromId($schemaId), (string) $schema, null);
     }
@@ -29,7 +29,7 @@ class CacheAdapter implements \FlixTech\SchemaRegistryApi\Registry\CacheAdapter
      *
      * @return void
      */
-    public function cacheSchemaWithSubjectAndVersion(AvroSchema $schema, string $subject, int $version)
+    public function cacheSchemaWithSubjectAndVersion(AvroSchema $schema, string $subject, int $version): void
     {
         Cache::add($this->makeKeyFromSubjectAndVersion($subject, $version), (string) $schema, null);
     }
@@ -42,7 +42,7 @@ class CacheAdapter implements \FlixTech\SchemaRegistryApi\Registry\CacheAdapter
      *
      * @return void
      */
-    public function cacheSchemaIdByHash(int $schemaId, string $schemaHash)
+    public function cacheSchemaIdByHash(int $schemaId, string $schemaHash): void
     {
         Cache::add($this->makeKeyFromHash($schemaHash), $schemaId, null);
     }
@@ -56,7 +56,7 @@ class CacheAdapter implements \FlixTech\SchemaRegistryApi\Registry\CacheAdapter
      * @throws \AvroSchemaParseException
      * @return AvroSchema|null
      */
-    public function getWithId(int $schemaId)
+    public function getWithId(int $schemaId): ?AvroSchema
     {
         $key = $this->makeKeyFromId($schemaId);
 
@@ -75,7 +75,7 @@ class CacheAdapter implements \FlixTech\SchemaRegistryApi\Registry\CacheAdapter
      *
      * @return int|null
      */
-    public function getIdWithHash(string $hash)
+    public function getIdWithHash(string $hash): ?int
     {
         $key = $this->makeKeyFromHash($hash);
 
@@ -96,7 +96,7 @@ class CacheAdapter implements \FlixTech\SchemaRegistryApi\Registry\CacheAdapter
      * @throws \AvroSchemaParseException
      * @return AvroSchema|null
      */
-    public function getWithSubjectAndVersion(string $subject, int $version)
+    public function getWithSubjectAndVersion(string $subject, int $version): ?AvroSchema
     {
         $key = $this->makeKeyFromSubjectAndVersion($subject, $version);
 


### PR DESCRIPTION
Allow all json extensions that are depending on the php version that is running.

It will remove this errors on `composer install`:

`````
Problem 1
    - onefit/events 1.1.4 requires ext-json ^1.6 -> the requested PHP extension json has the wrong version (7.4.11) installed.
    - onefit/events 1.1.3 requires ext-json ^1.6 -> the requested PHP extension json has the wrong version (7.4.11) installed.
    - onefit/events 1.1.2 requires ext-json ^1.6 -> the requested PHP extension json has the wrong version (7.4.11) installed.
    - onefit/events 1.1.1 requires ext-json ^1.6 -> the requested PHP extension json has the wrong version (7.4.11) installed.
    - onefit/events 1.1.0 requires ext-json ^1.6 -> the requested PHP extension json has the wrong version (7.4.11) installed.
    - Installation request for onefit/events ^1.1 -> satisfiable by onefit/events[1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4].

`````